### PR TITLE
Fix rule scanning for observables and sigma

### DIFF
--- a/petab/core.py
+++ b/petab/core.py
@@ -562,17 +562,19 @@ def create_condition_df(parameter_ids, condition_ids=None):
         An pandas.DataFrame with empty given rows and columns and all nan
         values
     """
-    df = pd.DataFrame(
-        data={
-            'conditionId': condition_ids,
-        })
+
+    data = {'conditionId': []}
+    for p in parameter_ids:
+        data[p] = []
+
+    df = pd.DataFrame(data)
     df.set_index(['conditionId'], inplace=True)
 
     if not condition_ids:
         return df
 
-    for f in parameter_ids:
-        df[f] = np.nan
+    for c in condition_ids:
+        df[c] = np.nan
 
     return df
 

--- a/petab/core.py
+++ b/petab/core.py
@@ -220,16 +220,17 @@ def assignment_rules_to_dict(
     """
     result = {}
 
-    # iterate over all parameters
-    for p in sbml_model.getListOfParameters():
-        parameter_id = p.getId()
+    # iterate over rules
+    for rule in sbml_model.getListOfRules():
+        if rule.getTypeCode() != libsbml.SBML_ASSIGNMENT_RULE:
+            continue
+        assignee = rule.getVariable()
+        parameter = sbml_model.getParameter(assignee)
         # filter
-        if filter_function(p):
-            result[parameter_id] = {
-                'name': p.getName(),
-                'formula': sbml_model.getAssignmentRuleByVariable(
-                    parameter_id
-                ).getFormula()
+        if parameter and filter_function(parameter):
+            result[assignee] = {
+                'name': parameter.getName(),
+                'formula': rule.getFormula()
             }
 
     # remove from model?
@@ -280,6 +281,9 @@ def get_sigmas(sbml_model, remove=False):
         filter_function=sbml_parameter_is_sigma,
         remove=remove
     )
+    # set correct observable name
+    sigmas = {re.sub(f'^sigma_', 'observable_', key): value['formula']
+              for key, value in sigmas.items()}
     return sigmas
 
 
@@ -546,3 +550,46 @@ def get_notnull_columns(df, candidates):
     """
     return [col for col in candidates
             if col in df and not np.all(df[col].isnull())]
+
+
+def create_condition_df(parameter_ids, condition_ids=None):
+    """Create empty condition dataframe
+
+    Arguments:
+        parameter_ids: the columns
+        condition_ids: the rows
+    Returns:
+        An pandas.DataFrame with empty given rows and columns and all nan
+        values
+    """
+    df = pd.DataFrame(
+        data={
+            'conditionId': condition_ids,
+        })
+    df.set_index(['conditionId'], inplace=True)
+
+    if not condition_ids:
+        return df
+
+    for f in parameter_ids:
+        df[f] = np.nan
+
+    return df
+
+
+def create_measurement_df():
+    """Create empty measurement dataframe"""
+
+    df = pd.DataFrame(data={
+        'observableId': [],
+        'preequilibrationConditionId': [],
+        'simulationConditionId': [],
+        'measurement': [],
+        'time': [],
+        'observableParameters': [],
+        'noiseParameters': [],
+        'observableTransformation': [],
+        'noiseDistribution': [],
+    })
+
+    return df

--- a/petab/lint.py
+++ b/petab/lint.py
@@ -1,8 +1,10 @@
 """Integrity checks and tests for specific features used"""
 
-import numpy as np
 from . import core
+
+import numpy as np
 import numbers
+import libsbml
 
 
 def _check_df(df, req_cols, name):
@@ -151,3 +153,21 @@ def assert_overrides_match_parameter_count(measurement_df, observables, noise):
             raise AssertionError(
                 f'Mismatch of noise parameter overrides in:\n{row}'
                 f'Expected 0 or {expected} but got {actual}')
+
+
+def print_sbml_errors(sbml_document, minimum_severity=libsbml.LIBSBML_SEV_WARNING):
+    """Print libsbml errors
+
+    Arguments:
+        sbml_document: libsbml.Document
+        minimum_severity: minimum severity level to print
+        (see libsbml.LIBSBML_SEV_*)
+    """
+
+    for error_idx in range(sbml_document.getNumErrors()):
+        error = sbml_document.getError(error_idx)
+        if error.getSeverity() >= minimum_severity:
+            category = error.getCategoryAsString()
+            severity = error.getSeverityAsString()
+            message = error.getMessage()
+            print(f'libSBML {severity} ({category}): {message}')


### PR DESCRIPTION
Iterate over rules and not parameters to avoid problems with parameter matching the conventions for observable/sigma names