### PR TITLE
Fix parameter mapping

### DIFF
--- a/petab/core.py
+++ b/petab/core.py
@@ -486,7 +486,7 @@ def get_optimization_to_simulation_parameter_mapping(
         _apply_overrides(
             overrides, row.simulationConditionId,
             row.observableId, override_type='noise')
-    
+
     handle_missing_overrides(mapping, measurement_df.observableId.unique())
 
     return mapping
@@ -502,8 +502,8 @@ def handle_missing_overrides(mapping_par_opt_to_par_sim, observable_ids):
             enumerate(mapping_par_opt_to_par_sim):
         for i_val, val in enumerate(mapping_for_condition):
             for observable_id in observable_ids:
-                if re.match("(noise|observable)Parameter[0-9]+_" \
-                        + observable_id, val):
+                if re.match("(noise|observable)Parameter[0-9]+_"
+                            + observable_id, val):
                     mapping_for_condition[i_val] = np.nan
                     missed_vals.append((i_condition, i_val, val))
 


### PR DESCRIPTION
* handle non-mapped parameters due to missing data: just set all corresponding parameter mappings to nan, since these will not have an impact on the parameter estimation anyway (because there are not data ...)
* fix problem with the generation of simulation conditions: use get_simulation_conditions function that searches simulationConditionIds and preequilibrationConditionIds, and returns then a dataframe of the conditions.

Note
------

The order of simulation conditions must be the same in petab and pypesto. Thus, in pypesto corresponding adaptations were made to ensure the order is the same (previously it was not)