### PR TITLE
Allow for condition-specific overrides of dynamic parameters (Closes …

### DIFF
--- a/petab/core.py
+++ b/petab/core.py
@@ -159,14 +159,7 @@ class Problem:
         return get_optimization_parameters(self.parameter_df)
 
     def get_dynamic_simulation_parameters(self):
-        return get_model_parameters(self.sbml_model)
-
-    def get_dynamic_parameters_from_sbml(self):
-        """
-        Provide list of IDS of parameters which are dynamic, i.e. not
-        fixed.
-        See get_dynamic_parameters_from_sbml.
-        """
+        """See `get_model_parameters`"""
         return get_model_parameters(self.sbml_model)
 
     def get_observables(self, remove=False):
@@ -586,7 +579,7 @@ def fill_in_nominal_values(mapping, parameter_df: pd.DataFrame):
 
     overrides = {row.name: row.nominalValue for _, row
                  in parameter_df.iterrows() if row.estimate != 1}
-    print(overrides)
+
     for i_condition, mapping_for_condition in enumerate(mapping):
         for i_val, val in enumerate(mapping_for_condition):
             if isinstance(val, str):

--- a/petab/core.py
+++ b/petab/core.py
@@ -775,8 +775,11 @@ def get_placeholders(formula_string, observable_id, override_type):
 
 
 def get_model_parameters(sbml_model: libsbml.Model):
-    """Return list of SBML model parameter IDs"""
-    return [p.getId() for p in sbml_model.getListOfParameters()]
+    """Return list of SBML model parameter IDs which are not AssignmentRule
+    targets for observables or sigmas"""
+
+    return [p.getId() for p in sbml_model.getListOfParameters()
+            if sbml_model.getAssignmentRuleByVariable(p.getId()) is None]
 
 
 def get_optimization_parameters(parameter_df):

--- a/petab/core.py
+++ b/petab/core.py
@@ -522,7 +522,7 @@ def _apply_dynamic_parameter_overrides(mapping,
                                        condition_df: pd.DataFrame,
                                        parameter_df: pd.DataFrame,
                                        par_sim_id_to_ix):
-    """Apply dynamic parameter overrides from condition table (inplace).
+    """Apply dynamic parameter overrides from condition table (in-place).
 
     Arguments:
         mapping, par_sim_id_to_ix:
@@ -552,7 +552,7 @@ def _check_dynamic_parameter_override(
     if 'parameterScale' not in parameter_df:
         return  # Nothing to check
 
-    # in case both parameter are in parameter table, their scale
+    # in case both parameters are in parameter table, their scale
     # must match.
     if overridee_id in parameter_df.index \
             and parameter_df.loc[overridee_id, 'parameterScale'] \

--- a/petab/core.py
+++ b/petab/core.py
@@ -159,8 +159,7 @@ class Problem:
         return get_optimization_parameters(self.parameter_df)
 
     def get_dynamic_simulation_parameters(self):
-        return get_dynamic_simulation_parameters(
-            self.sbml_model, self.parameter_df)
+        return get_model_parameters(self.sbml_model)
 
     def get_dynamic_parameters_from_sbml(self):
         """
@@ -168,7 +167,7 @@ class Problem:
         fixed.
         See get_dynamic_parameters_from_sbml.
         """
-        return get_dynamic_parameters_from_sbml(self.sbml_model)
+        return get_model_parameters(self.sbml_model)
 
     def get_observables(self, remove=False):
         """
@@ -539,13 +538,14 @@ def _apply_dynamic_parameter_overrides(mapping,
         for condition_idx, overrider_id \
                 in enumerate(condition_df[overridee_id]):
             if isinstance(overridee_id, str):
-                _check_dynamic_parameter_override(overridee_id, overrider_id,
-                                                parameter_df)
+                _check_dynamic_parameter_override(
+                    overridee_id, overrider_id, parameter_df)
                 mapping[condition_idx][par_sim_id_to_ix[overridee_id]] = \
                     overrider_id
 
 
-def _check_dynamic_parameter_override(overridee_id, overrider_id, parameter_df):
+def _check_dynamic_parameter_override(
+        overridee_id, overrider_id, parameter_df: pd.DataFrame):
     """Check for valid replacement of parameter overridee_id by overrider_id.
     Matching scales, etc."""
 
@@ -585,7 +585,7 @@ def fill_in_nominal_values(mapping, parameter_df: pd.DataFrame):
         return
 
     overrides = {row.name: row.nominalValue for _, row
-                 in parameter_df.iterrows() if row.estimate != 1 }
+                 in parameter_df.iterrows() if row.estimate != 1}
     print(overrides)
     for i_condition, mapping_for_condition in enumerate(mapping):
         for i_val, val in enumerate(mapping_for_condition):

--- a/petab/core.py
+++ b/petab/core.py
@@ -433,6 +433,9 @@ def get_optimization_to_simulation_parameter_mapping(
     be mapped to the simulation parameters. NaN is used where no mapping
     exists.
 
+    If no `par_sim_ids` is passed, parameter ordering will the one obtained
+    from `get_model_parameters()`.
+
     Parameters
     ----------
 

--- a/tests/test_petab.py
+++ b/tests/test_petab.py
@@ -261,19 +261,49 @@ class TestGetSimulationToOptimizationParameterMapping(object):
 
         assert actual == expected
 
+    def test_parameterized_condition_table(self):
+        condition_df = pd.DataFrame(data={
+            'conditionId': ['condition1', 'condition2', 'condition3'],
+            'conditionName': ['', 'Condition 2', ''],
+            'dynamicParameter1': ['dynamicOverride1_1',
+                                  'dynamicOverride1_2', 0]
+        })
+        condition_df.set_index('conditionId', inplace=True)
 
-def test_get_dynamic_parameters_from_sbml():
-    document = libsbml.SBMLDocument(3, 1)
-    model = document.createModel()
-    p = model.createParameter()
-    p.setId('dynamicParameter1')
-    p.setConstant(False)
-    p = model.createParameter()
-    p.setId('fixedParameter1')
-    p.setConstant(True)
+        measurement_df = pd.DataFrame(data={
+            'simulationConditionId': ['condition1', 'condition2',
+                                      'condition3'],
+            'observableId': ['obs1', 'obs2', 'obs1'],
+            'observableParameters': '',
+            'noiseParameters': '',
+        })
 
-    assert petab.get_dynamic_parameters_from_sbml(model) == [
-        'dynamicParameter1']
+        parameter_df = pd.DataFrame(data={
+            'parameterId': ['dynamicOverride1_1', 'dynamicOverride1_2'],
+            'parameterName': ['', '...'],  # ...
+        })
+
+        document = libsbml.SBMLDocument(3, 1)
+        model = document.createModel()
+        model.setTimeUnits("second")
+        model.setExtentUnits("mole")
+        model.setSubstanceUnits('mole')
+        model.createParameter().setId('dynamicParameter1')
+
+        assert petab.get_model_parameters(model) == ['dynamicParameter1']
+
+        actual = petab.get_optimization_to_simulation_parameter_mapping(
+            measurement_df=measurement_df,
+            condition_df=condition_df,
+            parameter_df=parameter_df,
+            sbml_model=model
+        )
+
+        expected = [['dynamicOverride1_1'],
+                    ['dynamicOverride1_2'],
+                    [0]]
+
+        assert actual == expected
 
 
 def test_get_observable_id():
@@ -346,3 +376,26 @@ def test_create_parameter_df(condition_df_2_conditions):
     assert actual == expected
 
     assert parameter_df.loc['p0', 'nominalValue'] == 3.0
+
+
+def test_fill_in_nominal_values():
+    parameter_df = pd.DataFrame(data={
+        'parameterId': ['estimated', 'not_estimated'],
+        'parameterName': ['', '...'],  # ...
+        'nominalValue': [0.0, 2.0],
+        'estimate': [1, 0]
+    })
+    parameter_df.set_index(['parameterId'], inplace=True)
+    mapping = [[1.0, 1.0], ['estimated', 'not_estimated']]
+
+    actual = mapping.copy()
+    petab.fill_in_nominal_values(actual, parameter_df)
+    expected = [[1.0, 1.0], ['estimated', 2.0]]
+    assert expected == actual
+
+    del parameter_df['estimate']
+    # should not replace
+    actual = mapping.copy()
+    petab.fill_in_nominal_values(actual, parameter_df)
+    expected = mapping.copy()
+    assert expected == actual


### PR DESCRIPTION
…#90)

- Remove duplicate functions
- Remove non-standard handling of constant parameters
- Replace fixed parameter names by nominal values during mapping
- Check override parameter scale where possible

- Does *not* implement recursive overrides. Not sure if we would want to have that.