### PR TITLE
Allow initial concentrations / sizes in condition table

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -380,7 +380,7 @@ const-naming-style=UPPER_CASE
 
 # Regular expression matching correct constant names. Overrides const-naming-
 # style.
-#const-rgx=
+const-rgx=^[a-zA-Z][a-zA-Z0-9]*((_[a-zA-Z0-9]+)*)?$
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.

--- a/.pylintrc
+++ b/.pylintrc
@@ -351,7 +351,7 @@ attr-naming-style=snake_case
 
 # Regular expression matching correct attribute names. Overrides attr-naming-
 # style.
-attr-rgx=^[a-z][a-z0-9]*((_[a-z0-9]+)*)?$
+attr-rgx=^[a-z_][a-z0-9]*((_[a-z0-9]+)*)?$
 
 # Bad variable names which should always be refused, separated by a comma.
 bad-names=foo,
@@ -443,7 +443,7 @@ variable-naming-style=snake_case
 
 # Regular expression matching correct variable names. Overrides variable-
 # naming-style.
-variable-rgx=^[a-z][a-z0-9]*((_[a-z0-9]+)*)?$
+variable-rgx=^[a-z_][a-z0-9]*((_[a-z0-9]+)*)?$
 
 
 [LOGGING]

--- a/doc/documentation_data_format.md
+++ b/doc/documentation_data_format.md
@@ -123,19 +123,27 @@ species/parameters/compartments in the following way:
 |... | ... | ... | ... |...| ...
 
 Row names are condition names as referenced in the measurement table below.
-Column names are global parameter IDs, IDs of species or compartments as given in
-the SBML model. These parameters will override any parameter values specified
-in the model. `parameterOrStateId`s and `conditionId`s must be unique.
+Column names are global parameter IDs, IDs of species or compartments as given
+in the SBML model. These parameters will override any parameter values
+specified in the model. `parameterOrStateId`s and `conditionId`s must be
+unique.
 
-If a species ID is provided, it is interpreted as the initial concentration of that species and will override the initial concentration given in the SBML model or given by a preequilibration condition. If `NaN` is provided for a condition, the initial concentration of the preequilibration (or the SBML model, if no preequilibration is defined) is used. 
+If a species ID is provided, it is interpreted as the initial
+concentration/amount of that species and will override the initial
+concentration/amount given in the SBML model or given by a preequilibration
+condition. If `NaN` is provided for a condition, the result of the
+preequilibration (or initial concentration/amount from the SBML model, if no
+preequilibration is defined) is used.
 
-If a compartment Id is provided, it is interpreted as the initial compartment size.
+If a compartment Id is provided, it is interpreted as the initial compartment
+size.
 
 Values for condition parameters may be provided either as numeric values, or
 as IDs defined in the SBML model, the parameter table or both.
 
 Row- and column-ordering are arbitrary, although specifying `parameterId`
-first may improve human readability. The `conditionName` column is optional and is used e.g. for the visualization routines.
+first may improve human readability. The `conditionName` column is optional
+and is used e.g. for the visualization routines.
 
 Additional columns are *not* allowed.
 

--- a/doc/documentation_data_format.md
+++ b/doc/documentation_data_format.md
@@ -109,12 +109,11 @@ Any parameters named `noiseParameter${1..n}` *must* be overwritten in the
 
 ## Condition table
 
-The condition table specifies parameters, initial values of species and compartments for specific
-simulation conditions (generally corresponding to different experimental
-conditions).
+The condition table specifies parameters, or initial values of species and
+compartments for specific simulation conditions (generally corresponding to
+different experimental conditions).
 
-This is specified as tab-separated value file with condition-specific
-species/parameters/compartments in the following way:
+This is specified as a tab-separated value file in the following way:
 
 | conditionId | [conditionName] | parameterOrStateOrCompartmentId1 | ... | parameterOrStateOrCompartmentId${n} |
 |---|---|---|---|---|
@@ -122,34 +121,47 @@ species/parameters/compartments in the following way:
 | conditionId2 | ... | ... | ...| ...
 |... | ... | ... | ... |...| ...
 
-Row names are condition names as referenced in the measurement table below.
-Column names are global parameter IDs, IDs of species or compartments as given
-in the SBML model. These parameters will override any parameter values
-specified in the model. `parameterOrStateId`s and `conditionId`s must be
-unique.
-
-If a species ID is provided, it is interpreted as the initial
-concentration/amount of that species and will override the initial
-concentration/amount given in the SBML model or given by a preequilibration
-condition. If `NaN` is provided for a condition, the result of the
-preequilibration (or initial concentration/amount from the SBML model, if no
-preequilibration is defined) is used.
-
-If a compartment Id is provided, it is interpreted as the initial compartment
-size.
-
-Values for condition parameters may be provided either as numeric values, or
-as IDs defined in the SBML model, the parameter table or both.
-
-Row- and column-ordering are arbitrary, although specifying `parameterId`
-first may improve human readability. The `conditionName` column is optional
-and is used e.g. for the visualization routines.
+Row- and column-ordering are arbitrary, although specifying `conditionId`
+first may improve human readability. 
 
 Additional columns are *not* allowed.
 
-*Note 1:* Instead of adding additional columns to the condition table, they
-can easily be added to a separate file, since every row of the condition table
-has `parameterOrStateId` as unique key.
+### Detailed field description
+
+- `conditionId` [STRING, NOT NULL]
+
+  Unique identifier for the simulation/experimental condition, to be referenced
+  by the measurement table described below.
+
+- `conditionName` [STRING, OPTIONAL]
+
+  Condition names are arbitrary strings to describe the given condition.
+  They may be used for reporting or visualization.
+
+- `${parameterOrStateOrCompartmentId1}`
+
+  Further columns may be global parameter IDs, IDs of species or compartments
+  as defined in the SBML model. Only one column is allowed per ID.
+  Values for these condition parameters may be provided either as numeric
+  values, or as IDs defined in the SBML model, the parameter table or both.
+
+  - `${parameterId}` 
+
+    The values will override any parameter values specified in the model.
+
+  - `${speciesId}`
+
+    If a species ID is provided, it is interpreted as the initial
+    concentration/amount of that species and will override the initial
+    concentration/amount given in the SBML model or given by a preequilibration
+    condition. If `NaN` is provided for a condition, the result of the
+    preequilibration (or initial concentration/amount from the SBML model, if
+    no preequilibration is defined) is used.
+  
+  - `${compartmentId}`
+
+    If a compartment ID is provided, it is interpreted as the initial
+    compartment size.
 
 
 ## Measurement table
@@ -305,7 +317,7 @@ Additional columns may be added.
 
 ### Detailed field description:
 
-- `parameterId` [STRING, NOT NULL, REFERENCES(sbml.parameterId)]
+- `parameterId` [STRING, NOT NULL]
 
   The `parameterId` of the parameter described in this row. This has be
   identical to the parameter IDs specified in the SBML model or in the

--- a/doc/documentation_data_format.md
+++ b/doc/documentation_data_format.md
@@ -109,36 +109,39 @@ Any parameters named `noiseParameter${1..n}` *must* be overwritten in the
 
 ## Condition table
 
-The condition table specifies parameters or *constant* species for specific
+The condition table specifies parameters, initial values of species and compartments for specific
 simulation conditions (generally corresponding to different experimental
 conditions).
 
 This is specified as tab-separated value file with condition-specific
-species/parameters in the following way:
+species/parameters/compartments in the following way:
 
-| conditionId | [conditionName] | parameterOrStateId1 | ... | parameterOrStateId${n} |
+| conditionId | [conditionName] | parameterOrStateOrCompartmentId1 | ... | parameterOrStateOrCompartmentId${n} |
 |---|---|---|---|---|
-| conditionId1 | conditionName1 | NUMERIC&#124;parameterId | ...| ...
+| conditionId1 | conditionName1 | NUMERIC&#124;parameterId&#124;stateId&#124;compartmentId | ...| ...
 | conditionId2 | ... | ... | ...| ...
 |... | ... | ... | ... |...| ...
 
 Row names are condition names as referenced in the measurement table below.
-Column names are global parameter IDs or IDs of constant species as given in
+Column names are global parameter IDs, IDs of species or compartments as given in
 the SBML model. These parameters will override any parameter values specified
 in the model. `parameterOrStateId`s and `conditionId`s must be unique.
 
+If a species ID is provided, it is interpreted as the initial concentration of that species and will override the initial concentration given in the SBML model or given by a preequilibration condition. If `NaN` is provided for a condition, the initial concentration of the preequilibration (or the SBML model, if no preequilibration is defined) is used. 
+
+If a compartment Id is provided, it is interpreted as the initial compartment size.
+
 Values for condition parameters may be provided either as numeric values, or
-as parameter IDs. In case parameter IDs are provided, they need to be defined
-in the SBML model, the parameter table or both. 
+as IDs defined in the SBML model, the parameter table or both.
 
 Row- and column-ordering are arbitrary, although specifying `parameterId`
-first may improve human readability. The `conditionName` column is optional.
+first may improve human readability. The `conditionName` column is optional and is used e.g. for the visualization routines.
 
 Additional columns are *not* allowed.
 
 *Note 1:* Instead of adding additional columns to the condition table, they
 can easily be added to a separate file, since every row of the condition table
-has `parameterId` as unique key.
+has `parameterOrStateId` as unique key.
 
 
 ## Measurement table

--- a/petab/__init__.py
+++ b/petab/__init__.py
@@ -21,3 +21,4 @@ from .sampling import *  # noqa: F403, F401
 from .sbml import *  # noqa: F403, F401
 from .yaml import *  # noqa: F403, F401
 from .version import __version__  # noqa: F401
+from .format_version import __format_version__  # noqa: F401

--- a/petab/lint.py
+++ b/petab/lint.py
@@ -81,11 +81,13 @@ def check_condition_df(
     if sbml_model is not None:
         for column_name in df.columns:
             if column_name != CONDITION_NAME \
-                    and sbml_model.getParameter(column_name) is None:
+                    and sbml_model.getParameter(column_name) is None\
+                    and sbml_model.getSpecies(column_name) is None\
+                    and sbml_model.getCompartment(column_name) is None:
                 raise AssertionError(
-                    "Condition table contains column for unknown parameter"
-                    f" {column_name}. Column names must match parameter Ids "
-                    "defined in the SBML model.")
+                    "Condition table contains column for unknown entity '"
+                    f"{column_name}'. Column names must match parameter, "
+                    "species or compartment IDs specified in the SBML model.")
 
 
 def check_measurement_df(df: pd.DataFrame) -> None:

--- a/petab/lint.py
+++ b/petab/lint.py
@@ -81,8 +81,8 @@ def check_condition_df(
     if sbml_model is not None:
         for column_name in df.columns:
             if column_name != CONDITION_NAME \
-                    and sbml_model.getParameter(column_name) is None\
-                    and sbml_model.getSpecies(column_name) is None\
+                    and sbml_model.getParameter(column_name) is None \
+                    and sbml_model.getSpecies(column_name) is None \
                     and sbml_model.getCompartment(column_name) is None:
                 raise AssertionError(
                     "Condition table contains column for unknown entity '"

--- a/petab/parameter_mapping.py
+++ b/petab/parameter_mapping.py
@@ -11,7 +11,7 @@ import libsbml
 import numpy as np
 import pandas as pd
 
-from . import lint, measurements, sbml
+from . import lint, measurements, sbml, core
 from . import ENV_NUM_THREADS
 from .C import *  # noqa: F403
 
@@ -299,7 +299,8 @@ def _apply_condition_parameters(mapping: ParMappingDict,
         if overridee_id == CONDITION_NAME:
             continue
 
-        mapping[overridee_id] = condition_df.loc[condition_id, overridee_id]
+        mapping[overridee_id] = core.to_float_if_float(
+            condition_df.loc[condition_id, overridee_id])
 
 
 def _apply_parameter_table(mapping: ParMappingDict,

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -7,6 +7,12 @@ import pandas as pd
 import petab
 import pytest
 from petab import (lint, sbml)  # noqa: E402
+from petab.C import *
+
+# import fixtures
+pytest_plugins = [
+   "tests.test_petab",
+]
 
 
 def test_assert_measured_observables_present_in_model():
@@ -294,3 +300,41 @@ def test_assert_measurement_conditions_present_in_condition_table():
     with pytest.raises(AssertionError):
         lint.assert_measurement_conditions_present_in_condition_table(
             measurement_df=measurement_df, condition_df=condition_df)
+
+
+def test_check_condition_df(minimal_sbml_model):
+    """Check that we correctly detect errors in condition table"""
+
+    _, sbml_model = minimal_sbml_model
+
+    condition_df = pd.DataFrame(data={
+        CONDITION_ID: ['condition1'],
+        'p1': [2.0],
+    })
+    condition_df.set_index(CONDITION_ID, inplace=True)
+
+    # parameter missing in model
+    with pytest.raises(AssertionError):
+        lint.check_condition_df(condition_df, sbml_model)
+
+    # fix:
+    sbml_model.createParameter().setId('p1')
+    lint.check_condition_df(condition_df, sbml_model)
+
+    # species missing in model
+    condition_df.loc['s1'] = [3.0]
+    with pytest.raises(AssertionError):
+        lint.check_condition_df(condition_df, sbml_model)
+
+    # fix:
+    sbml_model.createSpecies().setId('s1')
+    lint.check_condition_df(condition_df, sbml_model)
+
+    # compartment missing in model
+    condition_df.loc['c1'] = [4.0]
+    with pytest.raises(AssertionError):
+        lint.check_condition_df(condition_df, sbml_model)
+
+    # fix:
+    sbml_model.createCompartment().setId('c1')
+    lint.check_condition_df(condition_df, sbml_model)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -322,7 +322,7 @@ def test_check_condition_df(minimal_sbml_model):
     lint.check_condition_df(condition_df, sbml_model)
 
     # species missing in model
-    condition_df.loc['s1'] = [3.0]
+    condition_df['s1'] = [3.0]
     with pytest.raises(AssertionError):
         lint.check_condition_df(condition_df, sbml_model)
 
@@ -331,7 +331,7 @@ def test_check_condition_df(minimal_sbml_model):
     lint.check_condition_df(condition_df, sbml_model)
 
     # compartment missing in model
-    condition_df.loc['c1'] = [4.0]
+    condition_df['c1'] = [4.0]
     with pytest.raises(AssertionError):
         lint.check_condition_df(condition_df, sbml_model)
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -13,7 +13,7 @@ from petab.C import *
 
 # import fixtures
 pytest_plugins = [
-   "tests.test_petab",
+    "tests.test_petab",
 ]
 
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,11 +1,13 @@
 import os
 import subprocess
+from math import nan
 from unittest.mock import patch
 
 import libsbml
 import pandas as pd
-import petab
 import pytest
+
+import petab
 from petab import (lint, sbml)  # noqa: E402
 from petab.C import *
 
@@ -309,7 +311,7 @@ def test_check_condition_df(minimal_sbml_model):
 
     condition_df = pd.DataFrame(data={
         CONDITION_ID: ['condition1'],
-        'p1': [2.0],
+        'p1': [nan],
     })
     condition_df.set_index(CONDITION_ID, inplace=True)
 


### PR DESCRIPTION
@LeonardSchmiester:
- [x] Update documentation 

@dweindl:
- [x] Add special handling for compartments when checking condition table
- [x] .. add test case
- [x] Ensure NaN is considered valid input
- [x] .. add test case
~- [ ] Add something like `get_initial_states()`~
~- [ ] .. add test case~
